### PR TITLE
Make compatible with Varnish 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: c
 
 before_install:
-  - sudo apt-get update -q
-  - sudo apt-get install -qq apt-transport-https python-docutils
-  - curl https://repo.varnish-cache.org/debian/GPG-key.txt | sudo apt-key add -
-  - echo "deb https://repo.varnish-cache.org/ubuntu/ precise varnish-4.1" | sudo tee /etc/apt/sources.list.d/varnish-cache.list
-  - sudo apt-get update -q
-  - sudo apt-get install varnish libvarnishapi-dev
+  - sudo apt-get --quiet update
+  - sudo apt-get --quiet --quiet --yes install wget
+  - wget --no-directories --no-host-directories --recursive --accept '*.deb' --no-parent 'https://repo.varnish-cache.org/pkg/5.0.0/'
+  - sudo dpkg --install *.deb || sudo apt-get --quiet --quiet --yes install --fix-broken
 
 before_script:
   - ./autogen.sh

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 
-.. image:: https://travis-ci.org/carlosabalde/libvmod-synth.svg?branch=4.1
+.. image:: https://travis-ci.org/carlosabalde/libvmod-synth.svg?branch=5.x
    :alt: Travis CI badge
    :target: https://travis-ci.org/carlosabalde/libvmod-synth/
 

--- a/src/vmod_synth.c
+++ b/src/vmod_synth.c
@@ -48,7 +48,7 @@ init_function(VRT_CTX, struct vmod_priv *vcl_priv, enum vcl_event_e e)
             vcl_priv->free = free;
             break;
 
-        case VCL_EVENT_USE:
+        case VCL_EVENT_WARM:
             // Every time the VMOD is used by some VCL increase the global
             // version. This will be used to refresh cached files when the
             // VCL is reloaded.


### PR DESCRIPTION
`VCL_EVENT_USE` is no longer defined, see [fbd1c18cc891cd915dd33be55afb43371de1c8a6](https://github.com/varnishcache/varnish-cache/commit/fbd1c18cc891cd915dd33be55afb43371de1c8a6) and [25647b4833e8a3dfa163133ebfe01d92e7299e6f](https://github.com/varnishcache/varnish-cache/commit/25647b4833e8a3dfa163133ebfe01d92e7299e6f).